### PR TITLE
Wait with server check until the WebID is valid

### DIFF
--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -35,7 +35,7 @@ class TMDojo
     TMDojo() {
         auto app = GetApp();
         @network = cast<CTrackManiaNetwork>(app.Network);
-        startnew(Api::CheckServerWaitForValidWebId);
+        startnew(Api::checkServerWaitForValidWebId);
     }
 
     void FillBuffer(CSceneVehicleVisState@ vis) {

--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -35,7 +35,7 @@ class TMDojo
     TMDojo() {
         auto app = GetApp();
         @network = cast<CTrackManiaNetwork>(app.Network);
-        startnew(Api::checkServer);
+        startnew(Api::CheckServerWaitForValidWebId);
     }
 
     void FillBuffer(CSceneVehicleVisState@ vis) {

--- a/UI/Menu.as
+++ b/UI/Menu.as
@@ -11,7 +11,7 @@ void RenderMenu()
 		if (UI::MenuItem(Enabled ? "Turn OFF" : "Turn ON", "", false, true)) {
             Enabled = !Enabled;
             if (Enabled) {
-                startnew(Api::checkServer);
+                startnew(Api::checkServerWaitForValidWebId);
             }
 		}
 
@@ -20,7 +20,7 @@ void RenderMenu()
         if (DevMode && UI::MenuItem("Switch to " + otherApi + " " + otherUi , "", false, true)) {
             ApiUrl = otherApi;
             UiUrl = otherUi;
-            startnew(Api::checkServer);
+            startnew(Api::checkServerWaitForValidWebId);
 		}
 
         if (UI::MenuItem(OverlayEnabled ? "[X]  Overlay" : "[  ]  Overlay", "", false, true)) {
@@ -37,7 +37,7 @@ void RenderMenu()
 
         if (!g_dojo.serverAvailable && !g_dojo.checkingServer) {
             if (UI::MenuItem("Check server", "", false, true)) {
-                startnew(Api::checkServer);
+                startnew(Api::checkServerWaitForValidWebId);
             }
         }
 


### PR DESCRIPTION
The latest game update caused the webId and playerLogin to both be some new random UUID during starting. These two get set correctly once the user gets to the main menu. This fix delays the server check until the webId and playerLogin are not the same, which should at that point be the correct webId and playerLogin.