### PR TITLE
Fix duplicate uploads by copying recording state when starting upload

### DIFF
--- a/Api/Api.as
+++ b/Api/Api.as
@@ -94,14 +94,37 @@ namespace Api {
     }
 
     void PostRecordedData(ref @handle) {
-        g_dojo.recording = false;
 
-        if (!g_dojo.serverAvailable || !Enabled) {
-            g_dojo.latestRecordedTime = -6666;
-            g_dojo.membuff.Resize(0);
+        // Copy databuffer so TMDojo can keep recording with a clean state
+        g_dojo.membuff.Seek(0);
+        string dataBase64 = g_dojo.membuff.ReadToBase64(g_dojo.membuff.GetSize());
+        uint64 bufferSize = g_dojo.membuff.GetSize();
+
+        // Reset recording state, all data required to upload is available without the need of TMDojo instance
+        g_dojo.recording = false;
+        g_dojo.latestRecordedTime = -6666;
+        g_dojo.currentRaceTime = -6666;
+        g_dojo.membuff.Resize(0);
+
+        // Abort if server isn't available
+        if (!g_dojo.serverAvailable) {
+            print("[TMDojo]: Abort upload, server not available");
             return;
         }
 
+        // Abort if plugin is disabled
+        if (!Enabled) {
+            print("[TMDojo]: Abort upload, plugin disabled");
+            return;
+        } 
+        
+        // Abort save if buffer is too small
+        if (bufferSize < 10000) {
+            print("[TMDojo]: Not saving file, too little data");
+            return;
+        }
+       
+        // Setup variables for upload
         FinishHandle @fh = cast<FinishHandle>(handle);
         bool finished = fh.finished;
         CSmScriptPlayer@ smScript = fh.smScript;
@@ -110,17 +133,10 @@ namespace Api {
         CTrackManiaNetwork@ network = fh.network;
         int endRaceTime = fh.endRaceTime;
 
-        if (g_dojo.membuff.GetSize() < 10000) {
-            print("[TMDojo]: Not saving file, too little data");
-            g_dojo.membuff.Resize(0);
-            g_dojo.latestRecordedTime = -6666;
-            g_dojo.currentRaceTime = -6666;
-            g_dojo.recording = false;
-            return;
-        }
         if (!OnlySaveFinished || finished) {
-            print("[TMDojo]: Saving game data (size: " + g_dojo.membuff.GetSize() / 1024 + " kB)");
-            g_dojo.membuff.Seek(0);
+            print("[TMDojo]: Saving game data (size: " + bufferSize / 1024 + " kB)");
+
+            // Setup request URL
             string mapNameClean = Regex::Replace(rootMap.MapInfo.NameForUi, "\\$([0-9a-fA-F]{1,3}|[iIoOnNmMwWsSzZtTgG<>]|[lLhHpP](\\[[^\\]]+\\])?)", "").Replace(" ", "%20");
             string reqUrl = ApiUrl + "/replays" +
                                 "?mapName=" + Net::UrlEncode(mapNameClean) +
@@ -131,15 +147,22 @@ namespace Api {
                                 "&webId=" + network.PlayerInfo.WebServicesUserId +
                                 "&endRaceTime=" + endRaceTime +
                                 "&raceFinished=" + (finished ? "1" : "0");
-            // build up request instance
+
+            // Build request instance
             Net::HttpRequest req;
             req.Method = Net::HttpMethod::Post;
             req.Url = reqUrl;
-            req.Body = g_dojo.membuff.ReadToBase64(g_dojo.membuff.GetSize());
+
+            // Set body to base64 encoded memory buffer
+            req.Body = dataBase64;
+
+            // Build headers
             dictionary@ Headers = dictionary();
             Headers["Authorization"] = "dojo " + SessionId;
             Headers["Content-Type"] = "application/octet-stream";
             @req.Headers = Headers;
+
+            // Start and wait until request is finished
             req.Start();
             while (!req.Finished()) {
                 yield();
@@ -155,9 +178,5 @@ namespace Api {
                 UI::ShowNotification("TMDojo", "Uploaded replay successfully!", SUCCESS_COLOR);
             }
         }
-        g_dojo.recording = false;
-        g_dojo.latestRecordedTime = -6666;
-        g_dojo.currentRaceTime = -6666;
-        g_dojo.membuff.Resize(0);
     }
 }

--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -97,6 +97,11 @@ class TMDojo
 
     void Render()
 	{
+        // Do not start recording if the user is not authenticated or doesn't even have a SessionId
+        if (!pluginAuthed || SessionId == "") {
+            return;
+        }
+
 		auto app = GetApp();
 
 		auto sceneVis = app.GameScene;

--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -220,6 +220,7 @@ class TMDojo
                 @cast<FinishHandle>(fh).smScript = smScript;
                 @cast<FinishHandle>(fh).network = network;
                 cast<FinishHandle>(fh).endRaceTime = latestRecordedTime;
+                
                 startnew(Api::PostRecordedData, fh);
             } else {
                  // Record current data


### PR DESCRIPTION
Before, the references to the memory buffer and `latestRecordedTime` were used in the upload, and only reset after the upload was completed. This could cause duplicate uploads for unfinished replays whenever a replay was being uploaded and a run starts, as unfinished replays got uploaded when `latestRecordedTime > 0` and `currentTime < 0`

This fix changes the way replays get uploaded, by first copying all data that is required for uploads, and then resetting all recording state so that recording can resume as normal.