### PR TITLE
CP/Sector time recording

### DIFF
--- a/Api/Api.as
+++ b/Api/Api.as
@@ -175,8 +175,12 @@ namespace Api {
                                 "&webId=" + network.PlayerInfo.WebServicesUserId +
                                 "&endRaceTime=" + endRaceTime +
                                 "&raceFinished=" + (finished ? "1" : "0") +
-                                "&pluginVersion=" + g_dojo.version +
-                                "&sectorTimes=" + SectorTimesToString(sectorTimes);
+                                "&pluginVersion=" + g_dojo.version;
+            
+            // If sector times are available, add them to the request URL
+            if (sectorTimes.Length > 0) {
+                reqUrl += "&sectorTimes=" + SectorTimesToString(sectorTimes);
+            }
 
             // Build request instance
             Net::HttpRequest req;

--- a/Api/Api.as
+++ b/Api/Api.as
@@ -106,6 +106,19 @@ namespace Api {
         }
     }
 
+    // Parse list of uint values as a string joined by a comma delimiter
+    // [1,2,3,4,5] -> "1,2,3,4,5"
+    string SectorTimesToString(array<uint> times) {
+        string result = "";
+        for (uint i = 0; i < times.Length; i++) {
+            result += times[i] + "";
+            if (i < times.Length - 1) {
+                result += ",";
+            }
+        }
+        return result;
+    }
+
     void PostRecordedData(ref @handle) {
 
         // Copy databuffer so TMDojo can keep recording with a clean state
@@ -118,6 +131,7 @@ namespace Api {
         g_dojo.latestRecordedTime = -6666;
         g_dojo.currentRaceTime = -6666;
         g_dojo.membuff.Resize(0);
+        g_dojo.sectorTimes.Resize(0);
 
         // Abort if server isn't available
         if (!g_dojo.serverAvailable) {
@@ -145,6 +159,7 @@ namespace Api {
         CGameCtnChallenge@ rootMap = fh.rootMap;
         CTrackManiaNetwork@ network = fh.network;
         int endRaceTime = fh.endRaceTime;
+        array<uint> sectorTimes = fh.sectorTimes;
 
         if (!OnlySaveFinished || finished) {
             print("[TMDojo]: Saving game data (size: " + bufferSize / 1024 + " kB)");
@@ -160,7 +175,8 @@ namespace Api {
                                 "&webId=" + network.PlayerInfo.WebServicesUserId +
                                 "&endRaceTime=" + endRaceTime +
                                 "&raceFinished=" + (finished ? "1" : "0") +
-                                "&pluginVersion=" + g_dojo.version;
+                                "&pluginVersion=" + g_dojo.version +
+                                "&sectorTimes=" + SectorTimesToString(sectorTimes);
 
             // Build request instance
             Net::HttpRequest req;

--- a/Lib/DependencyNotifier.as
+++ b/Lib/DependencyNotifier.as
@@ -1,0 +1,33 @@
+namespace DependencyNotifier {
+
+    bool shownPlayerStateNotification = false;
+
+    void NotifyMissingPlayerStateDependency() {
+#if !DEPENDENCY_PLAYERSTATE
+        if (!shownPlayerStateNotification) {
+            print("TMDojo did not find optional 'PlayerState' plugin dependency");
+            UI::ShowNotification(
+                "TMDojo",
+                "We've noticed you don't have the 'PlayerState' plugin installed!\n\n" + 
+                    "If you want to record CP/sector times, please install it.\nThen reload this plugin or restart the script engine.\n\n" + 
+                    "F3 → Plugin Manager → Open manager → Search for 'PlayerState'", 
+                WARNING_COLOR,
+                20000
+            );
+            shownPlayerStateNotification = true;
+        }
+#else
+        if (shownPlayerStateNotification) {
+            print("TMDojo found optional 'PlayerState' plugin dependency, now recording sector times!");
+            UI::ShowNotification(
+                "TMDojo",
+                "Successfully installed 'PlayerState' plugin!\n\n" + 
+                    "CP/sector times will now be recorded!.",
+                SUCCESS_COLOR
+            );
+            shownPlayerStateNotification = false;
+        }
+#endif
+    }
+
+}

--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -106,7 +106,8 @@ class TMDojo
         if (!pluginAuthed || SessionId == "") {
             return;
         }
-
+        
+#if DEPENDENCY_PLAYERSTATE
         // Track CP times
         PlayerState::sTMData@ TMData = PlayerState::GetRaceData();
         if(TMData.dEventInfo.CheckpointChange && 
@@ -116,6 +117,7 @@ class TMDojo
         if(TMData.dEventInfo.PlayerStateChange && TMData.PlayerState == PlayerState::EPlayerState::EPlayerState_Countdown) {
             sectorTimes.Resize(0);
         }
+#endif
 
 
 		auto app = GetApp();

--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -8,6 +8,7 @@ class TMDojo
     int latestRecordedTime = -6666;
     CTrackManiaNetwork@ network;
 
+    array<uint> sectorTimes;
 
     // Player info
     string playerName;
@@ -106,6 +107,17 @@ class TMDojo
             return;
         }
 
+        // Track CP times
+        PlayerState::sTMData@ TMData = PlayerState::GetRaceData();
+        if(TMData.dEventInfo.CheckpointChange && 
+            TMData.dPlayerInfo.NumberOfCheckpointsPassed < (TMData.dMapInfo.NumberOfCheckpoints + 1)) {
+            sectorTimes.InsertLast(TMData.dPlayerInfo.LatestCPTime);
+        }
+        if(TMData.dEventInfo.PlayerStateChange && TMData.PlayerState == PlayerState::EPlayerState::EPlayerState_Countdown) {
+            sectorTimes.Resize(0);
+        }
+
+
 		auto app = GetApp();
 
 		auto sceneVis = app.GameScene;
@@ -190,6 +202,7 @@ class TMDojo
                 @cast<FinishHandle>(fh).smScript = smScript;
                 @cast<FinishHandle>(fh).network = network;
                 cast<FinishHandle>(fh).endRaceTime = latestRecordedTime;
+                cast<FinishHandle>(fh).sectorTimes = sectorTimes;
 
                 // https://github.com/GreepTheSheep/openplanet-mx-random special thanks to greep for getting accurate endRaceTime
 
@@ -224,6 +237,7 @@ class TMDojo
                 @cast<FinishHandle>(fh).smScript = smScript;
                 @cast<FinishHandle>(fh).network = network;
                 cast<FinishHandle>(fh).endRaceTime = latestRecordedTime;
+                cast<FinishHandle>(fh).sectorTimes = sectorTimes;
                 
                 startnew(Api::PostRecordedData, fh);
             } else {

--- a/Lib/FinishHandle.as
+++ b/Lib/FinishHandle.as
@@ -6,4 +6,5 @@ class FinishHandle
     CGameCtnChallenge@ rootMap;
     CTrackManiaNetwork@ network;
     int endRaceTime;
+    array<uint> sectorTimes;
 }

--- a/Main.as
+++ b/Main.as
@@ -9,6 +9,8 @@ void Render() {
     if (g_dojo !is null && Enabled) {
 		g_dojo.Render();
 	}
+
+    DependencyNotifier::NotifyMissingPlayerStateDependency();
 }
 
 void RenderInterface() {

--- a/Utils/Constants.as
+++ b/Utils/Constants.as
@@ -13,4 +13,5 @@ string GREEN = "\\$9f3";
 string ORANGE = "\\$fb3";
 
 vec4 SUCCESS_COLOR = vec4(0, 0.4, 0, 1);
+vec4 WARNING_COLOR = vec4(0.5, 0.4, 0, 1);
 vec4 ERROR_COLOR = vec4(0.4, 0, 0, 1);

--- a/info.toml
+++ b/info.toml
@@ -2,8 +2,8 @@
 name = "TMDojo"
 author = "TeamDojo"
 category = "Utilities"
-version = "0.2.1"
+version = "0.3.0"
 siteid = 180
 
 [script]
-dependencies = [ "VehicleState" ]
+dependencies = [ "VehicleState", "PlayerState" ]

--- a/info.toml
+++ b/info.toml
@@ -6,4 +6,5 @@ version = "0.3.0"
 siteid = 180
 
 [script]
-dependencies = [ "VehicleState", "PlayerState" ]
+dependencies = [ "VehicleState" ]
+optional_dependencies = [ "PlayerState" ]


### PR DESCRIPTION
This PR adds sector time recording, huge thanks to thommie for the PlayerState plugin ❤️ 

Changes:
- `PlayerState` plugin added as optional dependency
  - If not installed, a notification is shown that you need to install it and reload the TMDojo plugin.
  - If it is not installed, recording will still continue as normal, just without recording any CP times
- A `array<uint> sectorTimes` stores the sector times
- Based on the PlayerState event system, CP times are added
- When a run is finished, `sectorTimes` is converted to a string with ',' separator and sent to the server as a query parameter
  - https://github.com/Bux42/TMDojo/pull/165