### PR TITLE
use hud off method to get time when playing on online server

### DIFF
--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -163,10 +163,10 @@ class TMDojo
 
         auto playgroundScript = cast<CSmArenaRulesMode>(app.PlaygroundScript);
 
-        bool hudOff = false;
+        bool hudOff = !UI::IsGameUIVisible();
 
         if (app.CurrentPlayground !is null && app.CurrentPlayground.Interface !is null) {
-            if (!UI::IsGameUIVisible() || playgroundScript == null) {
+            if (hudOff || playgroundScript == null) {
                 if (@app.Network.PlaygroundClientScriptAPI != null) {
                     auto playgroundClientScriptAPI = cast<CGamePlaygroundClientScriptAPI>(app.Network.PlaygroundClientScriptAPI);
                     if (@playgroundClientScriptAPI != null) {

--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -166,17 +166,12 @@ class TMDojo
         bool hudOff = false;
 
         if (app.CurrentPlayground !is null && app.CurrentPlayground.Interface !is null) {
-            if (!UI::IsGameUIVisible()) {
-                hudOff = true;
-                if (@playgroundScript == null) {
-                    if (@app.Network.PlaygroundClientScriptAPI != null) {
-                        auto playgroundClientScriptAPI = cast<CGamePlaygroundClientScriptAPI>(app.Network.PlaygroundClientScriptAPI);
-                        if (@playgroundClientScriptAPI != null) {
-                            g_dojo.currentRaceTime = playgroundClientScriptAPI.GameTime - smScript.StartTime;
-                        }
+            if (!UI::IsGameUIVisible() || playgroundScript == null) {
+                if (@app.Network.PlaygroundClientScriptAPI != null) {
+                    auto playgroundClientScriptAPI = cast<CGamePlaygroundClientScriptAPI>(app.Network.PlaygroundClientScriptAPI);
+                    if (@playgroundClientScriptAPI != null) {
+                        g_dojo.currentRaceTime = playgroundClientScriptAPI.GameTime - smScript.StartTime;
                     }
-                } else {
-                    g_dojo.currentRaceTime = playgroundScript.Now - smScript.StartTime;
                 }
             } else {
                 g_dojo.currentRaceTime = smScript.CurrentRaceTime;


### PR DESCRIPTION
The method used to get currentRaceTime (ingame timer) was broken when playing in online server
Using the method to get time when HUD is turned off fixes the issue