### PR TITLE
Fix hud off issues by recording in the Update() function instead of Render()

### DIFF
--- a/Main.as
+++ b/Main.as
@@ -5,7 +5,7 @@ void Main() {
     print("TMDojo v" + g_dojo.version + " Init ");
 }
 
-void Render() {
+void Update(float dt) {
     if (g_dojo !is null && Enabled) {
 		g_dojo.Render();
 	}

--- a/info.toml
+++ b/info.toml
@@ -2,7 +2,7 @@
 name = "TMDojo"
 author = "TeamDojo"
 category = "Utilities"
-version = "0.3.0"
+version = "0.4.0"
 siteid = 180
 
 [script]


### PR DESCRIPTION
The issue that caused recording to stop in the middle of a run for some users has been identified and fixed

The Openplanet setting "Hide overlay on hidden game UI" disables the Render() loop when it is turned on and the ingame HUD is turned OFF

Moving the recording logic into the Update() loop instead fixed it

![image](https://user-images.githubusercontent.com/22957968/166149482-26df7d8b-e063-4dbb-804e-ae76eb329bd2.png)
