### PR TITLE
Add setting to ignore replays with respawns

### DIFF
--- a/Api/Api.as
+++ b/Api/Api.as
@@ -145,9 +145,16 @@ namespace Api {
             print("[TMDojo]: Not saving file, too little data");
             return;
         }
+
+        FinishHandle @fh = cast<FinishHandle>(handle);
+
+        // Abort save if replays contains respawns and settings is enabled to not upload replays with respawns
+        if (!SaveReplaysWithRespawns && fh.respawns > 0) {
+            print("[TMDojo]: Not saving file, replay contains respawns");
+            return;
+        }
        
         // Setup variables for upload
-        FinishHandle @fh = cast<FinishHandle>(handle);
         bool finished = fh.finished;
         CSmScriptPlayer@ smScript = fh.smScript;
         CGamePlaygroundUIConfig@ uiConfig = fh.uiConfig;
@@ -157,6 +164,8 @@ namespace Api {
         array<uint> sectorTimes = fh.sectorTimes;
 
         print("[TMDojo]: Saving game data (size: " + bufferSize / 1024 + " kB)");
+
+        return;
 
         // Setup request URL
         string mapNameClean = Regex::Replace(rootMap.MapInfo.NameForUi, "\\$([0-9a-fA-F]{1,3}|[iIoOnNmMwWsSzZtTgG<>]|[lLhHpP](\\[[^\\]]+\\])?)", "").Replace(" ", "%20");

--- a/Api/Api.as
+++ b/Api/Api.as
@@ -165,8 +165,6 @@ namespace Api {
 
         print("[TMDojo]: Saving game data (size: " + bufferSize / 1024 + " kB)");
 
-        return;
-
         // Setup request URL
         string mapNameClean = Regex::Replace(rootMap.MapInfo.NameForUi, "\\$([0-9a-fA-F]{1,3}|[iIoOnNmMwWsSzZtTgG<>]|[lLhHpP](\\[[^\\]]+\\])?)", "").Replace(" ", "%20");
         string reqUrl = ApiUrl + "/replays" +

--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -9,6 +9,7 @@ class TMDojo
     CTrackManiaNetwork@ network;
 
     array<uint> sectorTimes;
+    uint respawns;
 
     // Player info
     string playerName;
@@ -109,7 +110,7 @@ class TMDojo
         membuff.Write(vis.RRDamperLen);
     }
 
-    void Render()
+    void Update(float dt)
 	{
         // Do not start recording if the user is not authenticated or doesn't even have a SessionId
         if (!pluginAuthed || SessionId == "") {
@@ -187,6 +188,12 @@ class TMDojo
             }
         }
 
+        if (@smScript.Score != null) {
+            respawns = smScript.Score.NbRespawnsRequested;
+        } else {
+            respawns = 0;
+        }
+
         if (Enabled && OverlayEnabled && !hudOff) {     
             drawRecordingOverlay();
         }
@@ -209,6 +216,7 @@ class TMDojo
                 @cast<FinishHandle>(fh).network = network;
                 cast<FinishHandle>(fh).endRaceTime = latestRecordedTime;
                 cast<FinishHandle>(fh).sectorTimes = sectorTimes;
+                cast<FinishHandle>(fh).respawns = respawns;
 
                 // https://github.com/GreepTheSheep/openplanet-mx-random special thanks to greep for getting accurate endRaceTime
 
@@ -247,6 +255,7 @@ class TMDojo
                 @cast<FinishHandle>(fh).network = network;
                 cast<FinishHandle>(fh).endRaceTime = latestRecordedTime;
                 cast<FinishHandle>(fh).sectorTimes = sectorTimes;
+                cast<FinishHandle>(fh).respawns = respawns;
                 
                 startnew(Api::PostRecordedData, fh);
                 */

--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -208,15 +208,15 @@ class TMDojo
                 // Finished track
                 print("[TMDojo]: Finished");
 
-                ref @fh = FinishHandle();
-                cast<FinishHandle>(fh).finished = true;
-                @cast<FinishHandle>(fh).rootMap = rootMap;
-                @cast<FinishHandle>(fh).uiConfig = uiConfig;
-                @cast<FinishHandle>(fh).smScript = smScript;
-                @cast<FinishHandle>(fh).network = network;
-                cast<FinishHandle>(fh).endRaceTime = latestRecordedTime;
-                cast<FinishHandle>(fh).sectorTimes = sectorTimes;
-                cast<FinishHandle>(fh).respawns = respawns;
+                FinishHandle@ finishHandle = cast<FinishHandle>(FinishHandle());
+                finishHandle.finished = true;
+                @finishHandle.rootMap = rootMap;
+                @finishHandle.uiConfig = uiConfig;
+                @finishHandle.smScript = smScript;
+                @finishHandle.network = network;
+                finishHandle.endRaceTime = latestRecordedTime;
+                finishHandle.sectorTimes = sectorTimes;
+                finishHandle.respawns = respawns;
 
                 // https://github.com/GreepTheSheep/openplanet-mx-random special thanks to greep for getting accurate endRaceTime
 
@@ -236,10 +236,10 @@ class TMDojo
                 } else endRaceTimeAccurate = -1;
 
                 if (endRaceTimeAccurate > 0) {
-                    cast<FinishHandle>(fh).endRaceTime = endRaceTimeAccurate;
+                    finishHandle.endRaceTime = endRaceTimeAccurate;
                 }
 
-                startnew(Api::PostRecordedData, fh);
+                startnew(Api::PostRecordedData, finishHandle);
             } else if (latestRecordedTime > 0 && g_dojo.currentRaceTime < 0) {
                 // Give up
                 print("[TMDojo]: Give up");
@@ -247,17 +247,17 @@ class TMDojo
                 g_dojo.Reset();
 
                 /*
-                ref @fh = FinishHandle();
-                cast<FinishHandle>(fh).finished = false;
-                @cast<FinishHandle>(fh).rootMap = rootMap;
-                @cast<FinishHandle>(fh).uiConfig = uiConfig;
-                @cast<FinishHandle>(fh).smScript = smScript;
-                @cast<FinishHandle>(fh).network = network;
-                cast<FinishHandle>(fh).endRaceTime = latestRecordedTime;
-                cast<FinishHandle>(fh).sectorTimes = sectorTimes;
-                cast<FinishHandle>(fh).respawns = respawns;
+                FinishHandle@ finishHandle = cast<FinishHandle>(FinishHandle());
+                finishHandle.finished = false;
+                @finishHandle.rootMap = rootMap;
+                @finishHandle.uiConfig = uiConfig;
+                @finishHandle.smScript = smScript;
+                @finishHandle.network = network;
+                finishHandle.endRaceTime = latestRecordedTime;
+                finishHandle.sectorTimes = sectorTimes;
+                finishHandle.respawns = respawns;
                 
-                startnew(Api::PostRecordedData, fh);
+                startnew(Api::PostRecordedData, finishHandle);
                 */
             } else {
                  // Record current data

--- a/Lib/FinishHandle.as
+++ b/Lib/FinishHandle.as
@@ -7,4 +7,5 @@ class FinishHandle
     CTrackManiaNetwork@ network;
     int endRaceTime;
     array<uint> sectorTimes;
+    uint respawns;
 }

--- a/Main.as
+++ b/Main.as
@@ -7,9 +7,9 @@ void Main() {
 
 void Update(float dt) {
     if (g_dojo !is null && Enabled) {
-		g_dojo.Render();
+		g_dojo.Update(dt);
 	}
-
+    
     DependencyNotifier::NotifyMissingPlayerStateDependency();
 }
 

--- a/UI/Menu.as
+++ b/UI/Menu.as
@@ -31,11 +31,9 @@ void RenderMenu()
             DebugOverlayEnabled = !DebugOverlayEnabled;
 		}
 
-        /*
-        if (UI::MenuItem(OnlySaveFinished ? "[X]  Save finished runs only" : "[  ]  Save finished runs only", "", false, true)) {
-            OnlySaveFinished = !OnlySaveFinished;
+        if (UI::MenuItem(SaveReplaysWithRespawns ? "[X]  Save replays with respawns" : "[  ]  Save replays with respawns", "", false, true)) {
+            SaveReplaysWithRespawns = !SaveReplaysWithRespawns;
 		}
-        */
 
         if (!g_dojo.serverAvailable && !g_dojo.checkingServer) {
             if (UI::MenuItem("Check server", "", false, true)) {

--- a/UI/Menu.as
+++ b/UI/Menu.as
@@ -1,3 +1,15 @@
+string CheckMarkIcon(bool checked)
+{
+    return checked
+        ? Icons::CheckSquareO
+        : Icons::SquareO;
+}
+
+string CheckMarkWithLabel(bool checked, string label)
+{
+    return CheckMarkIcon(checked) + "  " + label;
+}
+
 void RenderMenu()
 {
     string menuTitle = "";
@@ -23,15 +35,15 @@ void RenderMenu()
             startnew(Api::checkServerWaitForValidWebId);
 		}
 
-        if (UI::MenuItem(OverlayEnabled ? "[X]  Overlay" : "[  ]  Overlay", "", false, true)) {
+        if (UI::MenuItem(CheckMarkWithLabel(OverlayEnabled, "Overlay"), "", false, true)) {
             OverlayEnabled = !OverlayEnabled;
 		}
 
-        if (DevMode && UI::MenuItem(DebugOverlayEnabled ? "[X]  Debug Overlay" : "[  ]  Debug Overlay", "", false, true)) {
+        if (DevMode && UI::MenuItem(CheckMarkWithLabel(DebugOverlayEnabled, "Debug Overlay"), "", false, true)) {
             DebugOverlayEnabled = !DebugOverlayEnabled;
 		}
 
-        if (UI::MenuItem(SaveReplaysWithRespawns ? "[X]  Save replays with respawns" : "[  ]  Save replays with respawns", "", false, true)) {
+        if (UI::MenuItem(CheckMarkWithLabel(SaveReplaysWithRespawns, "Save replays with respawns") , "", false, true)) {
             SaveReplaysWithRespawns = !SaveReplaysWithRespawns;
 		}
 

--- a/Utils/Settings.as
+++ b/Utils/Settings.as
@@ -21,3 +21,6 @@ bool DebugOverlayEnabled = false;
 
 [Setting name="TMDojoOverlayEnabled" description="Enable / Disable overlay"]
 bool OverlayEnabled = true;
+
+[Setting name="TMDojoSaveReplaysWithRespawns" description="Enable / Disable saving replays including respawns"]
+bool SaveReplaysWithRespawns = true;


### PR DESCRIPTION
This PR adds a setting to the plugin that allows you to enable/disable uploading replays that contain respawns.

The PR also contains some small tweaks to the Menu UI code to remove some duplicate code.

![image](https://user-images.githubusercontent.com/22432233/176993718-fe84b88a-c774-4b87-b72d-d71432a10983.png)
