### PR TITLE
Remove sector times using PlayerState

### DIFF
--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -117,17 +117,18 @@ class TMDojo
             return;
         }
         
-#if DEPENDENCY_PLAYERSTATE
+// Removed PlayerState sector times until a more permanent solution for sector times is made
+// #if DEPENDENCY_PLAYERSTATE
         // Track CP times
-        PlayerState::sTMData@ TMData = PlayerState::GetRaceData();
-        if(TMData.dEventInfo.CheckpointChange && 
-            TMData.dPlayerInfo.NumberOfCheckpointsPassed < uint(TMData.dMapInfo.NumberOfCheckpoints + 1)) {
-            sectorTimes.InsertLast(TMData.dPlayerInfo.LatestCPTime);
-        }
-        if(TMData.dEventInfo.PlayerStateChange && TMData.PlayerState == PlayerState::EPlayerState::EPlayerState_Countdown) {
-            sectorTimes.Resize(0);
-        }
-#endif
+        // PlayerState::sTMData@ TMData = PlayerState::GetRaceData();
+        // if(TMData.dEventInfo.CheckpointChange && 
+        //     TMData.dPlayerInfo.NumberOfCheckpointsPassed < uint(TMData.dMapInfo.NumberOfCheckpoints + 1)) {
+        //     sectorTimes.InsertLast(TMData.dPlayerInfo.LatestCPTime);
+        // }
+        // if(TMData.dEventInfo.PlayerStateChange && TMData.PlayerState == PlayerState::EPlayerState::EPlayerState_Countdown) {
+        //     sectorTimes.Resize(0);
+        // }
+// #endif
 
 
 		auto app = GetApp();

--- a/Main.as
+++ b/Main.as
@@ -10,7 +10,7 @@ void Update(float dt) {
 		g_dojo.Update(dt);
 	}
     
-    DependencyNotifier::NotifyMissingPlayerStateDependency();
+    // DependencyNotifier::NotifyMissingPlayerStateDependency();
 }
 
 void RenderInterface() {

--- a/info.toml
+++ b/info.toml
@@ -7,4 +7,4 @@ siteid = 180
 
 [script]
 dependencies = [ "VehicleState" ]
-optional_dependencies = [ "PlayerState" ]
+optional_dependencies = [ ]


### PR DESCRIPTION
The PlayerState plugin now depends on the MLHook and MLFeed race data plugins. This caused some crashes for users that did not have one of those dependencies installed.

For now, we've chosen to remove the sector time usage of PlayerState, remove the dependency, and not store sector times for new replays. We will add back sector times once we have a more permanent solution.