### PR TITLE
Fix plugin race timer retrieval code & add visual feedback when uploading a replay

### DIFF
--- a/Api/Api.as
+++ b/Api/Api.as
@@ -1,5 +1,5 @@
 namespace Api {
-    
+    bool UploadingReplay = false;
     // Workaround method for checkServer to ensure checkServer is only called when webId and playerLogin are not the equal
     void checkServerWaitForValidWebId() {
         while (g_dojo.network.PlayerInfo.Login == g_dojo.network.PlayerInfo.WebServicesUserId) {
@@ -198,10 +198,14 @@ namespace Api {
         @req.Headers = Headers;
 
         // Start and wait until request is finished
+        UploadingReplay = true;
+        
         req.Start();
         while (!req.Finished()) {
             yield();
         }
+
+        UploadingReplay = false;
 
         // Handle error status codes
         int status = req.ResponseCode();

--- a/Lib/Dojo.as
+++ b/Lib/Dojo.as
@@ -177,15 +177,9 @@ class TMDojo
         bool hudOff = !UI::IsGameUIVisible();
 
         if (app.CurrentPlayground !is null && app.CurrentPlayground.Interface !is null) {
-            if (hudOff || @playgroundScript == null) {
-                if (@app.Network.PlaygroundClientScriptAPI != null) {
-                    auto playgroundClientScriptAPI = cast<CGamePlaygroundClientScriptAPI>(app.Network.PlaygroundClientScriptAPI);
-                    if (@playgroundClientScriptAPI != null) {
-                        g_dojo.currentRaceTime = playgroundClientScriptAPI.GameTime - smScript.StartTime;
-                    }
-                }
-            } else {
-                g_dojo.currentRaceTime = smScript.CurrentRaceTime;
+            auto playgroundClientScriptAPI = cast<CGamePlaygroundClientScriptAPI>(app.Network.PlaygroundClientScriptAPI);
+            if (@playgroundClientScriptAPI != null) {
+                g_dojo.currentRaceTime = playgroundClientScriptAPI.GameTime - smScript.StartTime;
             }
         }
 

--- a/UI/RecordingOverlay.as
+++ b/UI/RecordingOverlay.as
@@ -16,6 +16,7 @@ void drawRecordingOverlay() {
 
     // Define colors
     vec4 white = vec4(1, 1, 1, 1);
+    vec4 orange = vec4(1, 0.5, 0, 1);
     vec4 gray = vec4(0.1, 0.1, 0.1, 1);
     vec4 red = vec4(0.95, 0.05, 0.05, 1);
 
@@ -24,7 +25,15 @@ void drawRecordingOverlay() {
     int circleTop = panelTop + 18;
     nvg::BeginPath();        
     nvg::Circle(vec2(circleLeft, circleTop), 10);
-    nvg::FillColor(g_dojo.recording ? red : gray);
+
+    if (g_dojo.recording) {
+        nvg::FillColor(red);
+    } else if (Api::UploadingReplay) {
+        nvg::FillColor(orange);
+    } else{
+        nvg::FillColor(gray);
+    }
+
     nvg::Fill();
     nvg::StrokeColor(gray);
     nvg::StrokeWidth(3);
@@ -34,7 +43,32 @@ void drawRecordingOverlay() {
     // Recording text
     int textLeft = panelLeft + 38;
     int textTop = panelTop + 23;
-    nvg::FillColor(g_dojo.recording ? red : white);
-    nvg::FillColor(white);
-    nvg::Text(textLeft, textTop, (g_dojo.recording ? "Recording" : "Not Recording"));
+
+    if (g_dojo.recording) {
+        nvg::FillColor(white);
+        nvg::Text(textLeft, textTop, "Recording");
+    } else if (Api::UploadingReplay) {
+        nvg::FillColor(white);
+        nvg::Text(textLeft, textTop, "Uploading");
+
+        nvg::BeginPath();
+
+        float timeOffset = (float(Time::Now) % 2000) / (Math::PI * 100);
+
+        // First arc
+        nvg::Arc(vec2(circleLeft, circleTop), 10.5, 1.2 + timeOffset, timeOffset, nvg::Winding::CCW);
+        nvg::FillColor(orange);
+        nvg::Fill();
+        nvg::ClosePath();
+
+        // Second arc on the opposite side
+        nvg::BeginPath();
+        nvg::Arc(vec2(circleLeft, circleTop), 10.5, 4.3 + timeOffset, 3.1 + timeOffset, nvg::Winding::CCW);
+        nvg::FillColor(orange);
+        nvg::Fill();
+        nvg::ClosePath();
+    } else{
+        nvg::FillColor(white);
+        nvg::Text(textLeft, textTop, "Not Recording");
+    }
 }

--- a/info.toml
+++ b/info.toml
@@ -2,7 +2,7 @@
 name = "TMDojo"
 author = "TeamDojo"
 category = "Utilities"
-version = "0.7.0"
+version = "0.7.1"
 siteid = 180
 
 [script]


### PR DESCRIPTION
We had two different methods to get the ingame timer, one of those methods stopped working (`smScript.CurrentRaceTime` no longer exists)
Now using `playgroundClientScriptAPI.GameTime - smScript.StartTime` to calculate the time
(tested in offline & online mode)

Now showing spinner when replay is being uplodaded

![Trackmania_Nx8V5BfB4T](https://github.com/user-attachments/assets/0c3df0ef-1e7f-4245-99a3-f87096f8101d)
